### PR TITLE
Add Bytes slicing

### DIFF
--- a/src/Bytes/Extra.elm
+++ b/src/Bytes/Extra.elm
@@ -1,10 +1,16 @@
-module Bytes.Extra exposing (fromByteValues, toByteValues)
+module Bytes.Extra exposing
+    ( empty
+    , fromByteValues, toByteValues
+    , slice, take, drop
+    )
 
 {-| Before the release of [elm/bytes], many packages would use `List Int`
 to represent bytes. To enable interaction with these packages, you can use
 `fromByteValues` and `toByteValues`.
 
+@docs empty
 @docs fromByteValues, toByteValues
+@docs slice, take, drop
 
 [elm/bytes]: https://package.elm-lang.org/packages/elm/bytes/latest/
 
@@ -15,6 +21,110 @@ import Bytes.Decode
 import Bytes.Decode.Extra
 import Bytes.Encode
 import Bytes.Encode.Extra
+
+
+{-| An empty `Bytes`. Useful for default cases or unreachable branches.
+
+    import Bytes
+
+    Bytes.width empty
+        --> 0
+
+-}
+empty : Bytes
+empty =
+    Bytes.Encode.encode (Bytes.Encode.sequence [])
+
+
+{-| Slice a segment from a `Bytes`
+
+    fromByteValues (List.range 0 20)
+        |> slice 5 10
+        |> toByteValues
+        --> [ 5, 6, 7, 8, 9 ]
+
+-}
+slice : Int -> Int -> Bytes -> Bytes
+slice from to buffer =
+    let
+        toKeep =
+            min (to - from) (Bytes.width buffer - to)
+
+        decoder =
+            Bytes.Decode.map2 (\_ v -> v)
+                (Bytes.Decode.bytes from)
+                (Bytes.Decode.bytes toKeep)
+    in
+    case Bytes.Decode.decode decoder buffer of
+        Just v ->
+            v
+
+        Nothing ->
+            empty
+
+
+{-| A prefix of a `Bytes`
+
+    fromByteValues (List.range 0 20)
+        |> take 5
+        |> toByteValues
+        --> [ 0, 1, 2, 3, 4 ]
+
+Returns the input when more than `Bytes.width input` values are taken
+
+    fromByteValues (List.range 0 20)
+        |> take 100
+        |> toByteValues
+        --> List.range 0 20
+
+-}
+take : Int -> Bytes -> Bytes
+take size buffer =
+    case Bytes.Decode.decode (Bytes.Decode.bytes size) buffer of
+        Just v ->
+            v
+
+        Nothing ->
+            buffer
+
+
+{-| A suffix of a `Bytes`
+
+    fromByteValues (List.range 0 20)
+        |> drop 15
+        |> toByteValues
+        --> [ 15, 16, 17, 18, 19, 20 ]
+
+Returns `empty` when all elements are dropped:
+
+    fromByteValues (List.range 0 20)
+        |> drop 100
+        |> toByteValues
+        --> []
+
+-}
+drop : Int -> Bytes -> Bytes
+drop size buffer =
+    let
+        toKeep =
+            Bytes.width buffer - size
+    in
+    if toKeep <= 0 then
+        empty
+
+    else
+        let
+            decoder =
+                Bytes.Decode.map2 (\_ v -> v)
+                    (Bytes.Decode.bytes size)
+                    (Bytes.Decode.bytes toKeep)
+        in
+        case Bytes.Decode.decode decoder buffer of
+            Just v ->
+                v
+
+            Nothing ->
+                empty
 
 
 {-| Convert a `List Int` to `Bytes`. Each `Int` represents a single byte,


### PR DESCRIPTION
This PR adds `empty`, `slice` and its specializations `take` and `drop`. These are function that I regularly need when working with bytes.

I also noticed that a link in the header is not working (even though it seems like it should). 