### PR TITLE
Implement mapX using only map (and no andThen)

### DIFF
--- a/src/Bytes/Decode/Extra.elm
+++ b/src/Bytes/Decode/Extra.elm
@@ -1,7 +1,7 @@
 module Bytes.Decode.Extra exposing
     ( list, byteValues
     , andMap, hardcoded
-    , map6, map7, map8
+    , map6, map7, map8, map16
     , onlyOks, onlyJusts
     )
 
@@ -57,7 +57,7 @@ makes an equivalent to `Json.Decode.Pipeline.optional` difficult to impossible.
 
 ## Extra maps
 
-@docs map6, map7, map8
+@docs map6, map7, map8, map16
 
 
 ## Working with Results and Maybes
@@ -146,23 +146,78 @@ andMap aDecoder fnDecoder =
 
 {-| -}
 map6 : (a -> b -> c -> d -> e -> f -> result) -> Decoder a -> Decoder b -> Decoder c -> Decoder d -> Decoder e -> Decoder f -> Decoder result
-map6 f decoderA decoderB decoderC decoderD decoderE decoderF =
-    map5 f decoderA decoderB decoderC decoderD decoderE
-        |> andMap decoderF
+map6 f b1 b2 b3 b4 b5 b6 =
+    let
+        d1 =
+            Bytes.Decode.map4 (\a b c d -> f a b c d) b1 b2 b3 b4
+
+        d2 =
+            Bytes.Decode.map3 (\h a b -> h a b) d1 b5 b6
+    in
+    d2
 
 
 {-| -}
 map7 : (a -> b -> c -> d -> e -> f -> g -> result) -> Decoder a -> Decoder b -> Decoder c -> Decoder d -> Decoder e -> Decoder f -> Decoder g -> Decoder result
-map7 f decoderA decoderB decoderC decoderD decoderE decoderF decoderG =
-    map4 f decoderA decoderB decoderC decoderD
-        |> andThen (\g -> map3 g decoderE decoderF decoderG)
+map7 f b1 b2 b3 b4 b5 b6 b7 =
+    let
+        d1 =
+            Bytes.Decode.map4 (\a b c d -> f a b c d) b1 b2 b3 b4
+
+        d2 =
+            Bytes.Decode.map4 (\h a b c -> h a b c) d1 b5 b6 b7
+    in
+    d2
 
 
 {-| -}
 map8 : (a -> b -> c -> d -> e -> f -> g -> h -> result) -> Decoder a -> Decoder b -> Decoder c -> Decoder d -> Decoder e -> Decoder f -> Decoder g -> Decoder h -> Decoder result
-map8 f decoderA decoderB decoderC decoderD decoderE decoderF decoderG decoderH =
-    map4 f decoderA decoderB decoderC decoderD
-        |> andThen (\g -> map4 g decoderE decoderF decoderG decoderH)
+map8 f b1 b2 b3 b4 b5 b6 b7 b8 =
+    let
+        d1 =
+            Bytes.Decode.map4 (\a b c d -> f a b c d) b1 b2 b3 b4
+
+        d2 =
+            Bytes.Decode.map5 (\h a b c d -> h a b c d) d1 b5 b6 b7 b8
+    in
+    d2
+
+
+{-| -}
+map16 :
+    (b1 -> b2 -> b3 -> b4 -> b5 -> b6 -> b7 -> b8 -> b9 -> b10 -> b11 -> b12 -> b13 -> b14 -> b15 -> b16 -> result)
+    -> Decoder b1
+    -> Decoder b2
+    -> Decoder b3
+    -> Decoder b4
+    -> Decoder b5
+    -> Decoder b6
+    -> Decoder b7
+    -> Decoder b8
+    -> Decoder b9
+    -> Decoder b10
+    -> Decoder b11
+    -> Decoder b12
+    -> Decoder b13
+    -> Decoder b14
+    -> Decoder b15
+    -> Decoder b16
+    -> Decoder result
+map16 f b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 =
+    let
+        d1 =
+            Bytes.Decode.map4 (\a b c d -> f a b c d) b1 b2 b3 b4
+
+        d2 =
+            Bytes.Decode.map5 (\h a b c d -> h a b c d) d1 b5 b6 b7 b8
+
+        d3 =
+            Bytes.Decode.map5 (\h a b c d -> h a b c d) d2 b9 b10 b11 b12
+
+        d4 =
+            Bytes.Decode.map5 (\h a b c d -> h a b c d) d3 b13 b14 b15 b16
+    in
+    d4
 
 
 {-| A neat way to fill in predetermined information that's not part of the data

--- a/tests/TestMaps.elm
+++ b/tests/TestMaps.elm
@@ -1,0 +1,103 @@
+module TestMaps exposing (suite)
+
+import Bytes exposing (Endianness(..))
+import Bytes.Decode as Decode
+import Bytes.Decode.Extra as Decode
+import Bytes.Extra as Bytes
+import Expect
+import Fuzz
+import Test exposing (..)
+
+
+suite =
+    describe "Decode.Extra.mapX"
+        [ test "map6" <|
+            \_ ->
+                let
+                    input =
+                        List.range 0 5
+
+                    decoder =
+                        Decode.map6 (\a b c d e f -> [ a, b, c, d, e, f ])
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                in
+                input
+                    |> Bytes.fromByteValues
+                    |> Decode.decode decoder
+                    |> Expect.equal (Just input)
+        , test "map7" <|
+            \_ ->
+                let
+                    input =
+                        List.range 0 6
+
+                    decoder =
+                        Decode.map7 (\a b c d e f g -> [ a, b, c, d, e, f, g ])
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                in
+                input
+                    |> Bytes.fromByteValues
+                    |> Decode.decode decoder
+                    |> Expect.equal (Just input)
+        , test "map8" <|
+            \_ ->
+                let
+                    input =
+                        List.range 0 7
+
+                    decoder =
+                        Decode.map8 (\a b c d e f g h -> [ a, b, c, d, e, f, g, h ])
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                in
+                input
+                    |> Bytes.fromByteValues
+                    |> Decode.decode decoder
+                    |> Expect.equal (Just input)
+        , test "map16" <|
+            \_ ->
+                let
+                    input =
+                        List.range 0 15
+
+                    decoder =
+                        Decode.map16 (\a b c d e f g h i j k l m n o p -> [ a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p ])
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                            Decode.unsignedInt8
+                in
+                input
+                    |> Bytes.fromByteValues
+                    |> Decode.decode decoder
+                    |> Expect.equal (Just input)
+        ]


### PR DESCRIPTION
The use of applicative (mapX) is generally prefered over monad (andThen)
because andThen creates a closure. I'm not sure how relevant this
currently is in elm, but still seems good practice to only use the maps.

Also added map16, which can be useful when decoding big chunks